### PR TITLE
User can create payments for a loan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,3 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'responders', '~> 2.0'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end
+
+group :test do
+  gem 'shoulda-matchers', '~> 3.1'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     slop (3.6.0)
     spring (1.3.6)
     sprockets (3.3.4)
@@ -176,6 +178,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-matchers (~> 3.1)
   spring
   sqlite3
   turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
+    responders (2.2.0)
+      railties (>= 4.2.0, < 5.1)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -170,6 +172,7 @@ DEPENDENCIES
   jquery-rails
   pry
   rails (= 4.2.4)
+  responders (~> 2.0)
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
@@ -180,4 +183,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -1,7 +1,13 @@
 class Api::V1::PaymentsController < ApiController
   def create
     loan = Loan.find(params[:loan_id])
-    respond_with loan.payments.create(payment_params), location: nil
+    payment = loan.payments.new(payment_params)
+
+    if loan.payment_under_balance?(payment) && payment.save
+      respond_with payment, location: nil
+    else
+      render json: { errors: payment.errors.full_messages }, status: :bad_request 
+    end
   end
 
   private

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::PaymentsController < ApiController
+  def create
+    loan = Loan.find(params[:loan_id])
+    respond_with loan.payments.create(payment_params), location: nil
+  end
+
+  private
+
+  def payment_params
+    params.require(:payment).permit(:amount)
+  end
+end

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -3,10 +3,10 @@ class Api::V1::PaymentsController < ApiController
     loan = Loan.find(params[:loan_id])
     payment = loan.payments.new(payment_params)
 
-    if loan.payment_under_balance?(payment) && payment.save
+    if payment.save && loan.payment_under_balance?(payment)
       respond_with payment, location: nil
     else
-      render json: { errors: payment.errors.full_messages }, status: :bad_request 
+      render json: { errors: payment.errors.full_messages }, status: :bad_request
     end
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,4 @@
+class ApiController < ApplicationController
+  protect_from_forgery with: :null_session
+  respond_to :json
+end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -1,2 +1,3 @@
 class Loan < ActiveRecord::Base
+  has_many :payments
 end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -6,7 +6,7 @@ class Loan < ActiveRecord::Base
   end
 
   def payment_under_balance?(payment)
-    if payment.amount > outstanding_balance
+    if payment.amount.nil? || payment.amount > outstanding_balance
       payment.errors.add(:amount, 'cannot exceed outstanding loan balance')
       return false
     end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -1,3 +1,15 @@
 class Loan < ActiveRecord::Base
   has_many :payments
+
+  def outstanding_balance
+    funded_amount - payments.sum(:amount)
+  end
+
+  def payment_under_balance?(payment)
+    if payment.amount > outstanding_balance
+      payment.errors.add(:amount, 'cannot exceed outstanding loan balance')
+      return false
+    end
+    true
+  end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,3 @@
+class Payment < ActiveRecord::Base
+  belongs_to :loan
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -4,4 +4,16 @@ class Payment < ActiveRecord::Base
   validates :amount, format: { with: /\A\d+\.?\d{0,2}\z/ }
   validates :amount, numericality: true
   validates :amount, presence: true
+
+  def amount=(val)
+    write_attribute :amount, val.to_f if numeric?(val)
+  end
+
+  private
+
+  def numeric?(val)
+    !!Kernel.Float(val)
+  rescue TypeError, ArgumentError
+    false
+  end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,7 +5,7 @@ class Payment < ActiveRecord::Base
   validates :amount, numericality: true
   validates :amount, presence: true
 
-  before_create :save_payment_date
+  before_save :save_payment_date
 
   def amount=(val)
     write_attribute :amount, val.to_f if numeric?(val)

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,3 +1,7 @@
 class Payment < ActiveRecord::Base
   belongs_to :loan
+
+  validates :amount, format: { with: /\A\d+\.?\d{0,2}\z/ }
+  validates :amount, numericality: true
+  validates :amount, presence: true
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,6 +5,8 @@ class Payment < ActiveRecord::Base
   validates :amount, numericality: true
   validates :amount, presence: true
 
+  before_create :save_payment_date
+
   def amount=(val)
     write_attribute :amount, val.to_f if numeric?(val)
   end
@@ -15,5 +17,9 @@ class Payment < ActiveRecord::Base
     !!Kernel.Float(val)
   rescue TypeError, ArgumentError
     false
+  end
+
+  def save_payment_date
+    write_attribute :payment_date, Time.now.strftime('%B %d, %Y')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,11 @@
 Rails.application.routes.draw do
-  resources :loans, defaults: {format: :json}
+  resources :loans, defaults: { format: :json }
+
+  namespace :api, defaults: { format: :json } do
+    namespace :v1 do
+      resources :loans, only: [:show] do
+        resources :payments, only: [:create]
+      end
+    end
+  end
 end

--- a/db/migrate/20160625185525_create_payments.rb
+++ b/db/migrate/20160625185525_create_payments.rb
@@ -1,0 +1,11 @@
+class CreatePayments < ActiveRecord::Migration
+  def change
+    create_table :payments do |t|
+      t.decimal :amount
+      t.datetime :payment_date
+      t.references :loan, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160625200819_change_payment_date_in_payment.rb
+++ b/db/migrate/20160625200819_change_payment_date_in_payment.rb
@@ -1,0 +1,5 @@
+class ChangePaymentDateInPayment < ActiveRecord::Migration
+  def change
+    change_column :payments, :payment_date, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160625185525) do
+ActiveRecord::Schema.define(version: 20160625200819) do
 
   create_table "loans", force: :cascade do |t|
     t.decimal  "funded_amount", precision: 8, scale: 2
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20160625185525) do
 
   create_table "payments", force: :cascade do |t|
     t.decimal  "amount"
-    t.datetime "payment_date"
+    t.text     "payment_date"
     t.integer  "loan_id"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150903195334) do
+ActiveRecord::Schema.define(version: 20160625185525) do
 
   create_table "loans", force: :cascade do |t|
     t.decimal  "funded_amount", precision: 8, scale: 2
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
   end
+
+  create_table "payments", force: :cascade do |t|
+    t.decimal  "amount"
+    t.datetime "payment_date"
+    t.integer  "loan_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "payments", ["loan_id"], name: "index_payments_on_loan_id"
 
 end

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -2,4 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Loan, type: :model do
   it { should have_many(:payments) }
+
+  it 'calculates the outstanding_balance' do
+    loan = Loan.create(funded_amount: 10_000.00)
+    loan.payments.create(amount: 5000.00)
+    loan.payments.create(amount: 2000.00)
+
+    expect(loan.outstanding_balance).to eq 3000.0
+  end
+
+  it 'can check if a payment exceeds the loan' do
+    loan = Loan.create(funded_amount: 10_000.00)
+    payment = loan.payments.create(amount: 12_000.00)
+
+    expect(loan.payment_under_balance?(payment)).to eq false
+  end
 end

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Loan, type: :model do
+  let(:loan) { Loan.create(funded_amount: 10_000.00) }
+
   it { should have_many(:payments) }
 
   it 'calculates the outstanding_balance' do
-    loan = Loan.create(funded_amount: 10_000.00)
     loan.payments.create(amount: 5000.00)
     loan.payments.create(amount: 2000.00)
 
@@ -12,7 +13,6 @@ RSpec.describe Loan, type: :model do
   end
 
   it 'can check if a payment exceeds the loan' do
-    loan = Loan.create(funded_amount: 10_000.00)
     payment = loan.payments.create(amount: 12_000.00)
 
     expect(loan.payment_under_balance?(payment)).to eq false

--- a/spec/models/loan_spec.rb
+++ b/spec/models/loan_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Loan, type: :model do
+  it { should have_many(:payments) }
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe Payment, type: :model do
 
     expect(payment.amount).to eq 10_000.00
   end
+
+  it 'should have a human readable payment date upon creation' do
+    payment = Payment.create(amount: '10000.00')
+
+    expect(payment.payment_date).to eq 'June 25, 2016'
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe Payment, type: :model do
   it { should_not allow_value(10_000.456).for(:amount) }
   it { should validate_numericality_of(:amount) }
   it { should validate_presence_of(:amount) }
+
+  it 'should write amount as a decimal' do
+    payment = Payment.create(amount: '10000.00')
+
+    expect(payment.amount).to eq 10_000.00
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe Payment, type: :model do
   it 'should have a human readable payment date upon creation' do
     payment = Payment.create(amount: '10000.00')
 
-    expect(payment.payment_date).to eq 'June 25, 2016'
+    expect(payment.payment_date).to eq Time.now.strftime('%B %d, %Y')
   end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Payment, type: :model do
+  let(:payment) { Payment.create(amount: '10000.00') }
+
   it { should belong_to(:loan) }
   it { should allow_value(10_000.00).for(:amount) }
   it { should_not allow_value(10_000.456).for(:amount) }
@@ -8,14 +10,10 @@ RSpec.describe Payment, type: :model do
   it { should validate_presence_of(:amount) }
 
   it 'should write amount as a decimal' do
-    payment = Payment.create(amount: '10000.00')
-
     expect(payment.amount).to eq 10_000.00
   end
 
   it 'should have a human readable payment date upon creation' do
-    payment = Payment.create(amount: '10000.00')
-
     expect(payment.payment_date).to eq Time.now.strftime('%B %d, %Y')
   end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Payment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should belong_to(:loan) }
+  it { should allow_value(10_000.00).for(:amount) }
+  it { should_not allow_value(10_000.456).for(:amount) }
+  it { should validate_numericality_of(:amount) }
+  it { should validate_presence_of(:amount) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,12 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/loans/:id/payments', type: :request do
+  context 'with valid data' do
+    it 'creates a payment record for the specified loan' do
+      loan = Loan.create(funded_amount: 10_000.00)
+
+      post "/api/v1/loans/#{loan.id}/payments", payment: { amount: 5000.00 }
+
+      expect(body.response).to eq 201
+
+      parsed_response = JSON.parse(response.body)
+      payment = loan.payments.last
+
+      expect(parsed_response).to eq(
+        payment_date: payment.payment_date,
+        amount: 5000.00
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
 
       parsed_response = JSON.parse(response.body)
 
-      expect(parsed_response.errors[0]).to eq 'Payment exceeds the outstanding balance'
+      expect(parsed_response['errors'][0]).to eq 'Amount cannot exceed outstanding loan balance'
     end
   end
 end

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -1,21 +1,20 @@
 require 'rails_helper'
 
-RSpec.describe 'POST /api/v1/loans/:id/payments', type: :request do
+RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
   context 'with valid data' do
     it 'creates a payment record for the specified loan' do
       loan = Loan.create(funded_amount: 10_000.00)
 
       post "/api/v1/loans/#{loan.id}/payments", payment: { amount: 5000.00 }
 
-      expect(body.response).to eq 201
+      expect(response.status).to eq 201
 
       parsed_response = JSON.parse(response.body)
       payment = loan.payments.last
 
-      expect(parsed_response).to eq(
-        payment_date: payment.payment_date,
-        amount: 5000.00
-      )
+      expect(parsed_response['id']).to eq payment.id
+      expect(parsed_response['amount']).to eq '5000.0'
+      expect(parsed_response['payment_date']).to eq payment.payment_date
     end
   end
 end

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
+  let(:loan) { Loan.create(funded_amount: 10_000.00) }
+
   context 'with valid data' do
     it 'creates a payment record for the specified loan' do
-      loan = Loan.create(funded_amount: 10_000.00)
-
       post "/api/v1/loans/#{loan.id}/payments", payment: { amount: 5000.00 }
 
       expect(response.status).to eq 201
@@ -20,8 +20,6 @@ RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
 
   context 'with invalid data' do
     it 'should return validation errors' do
-      loan = Loan.create(funded_amount: 10_000.00)
-
       post "/api/v1/loans/#{loan.id}/payments", payment: { amount: 'jf' }
 
       expect(response.status).to eq 400
@@ -40,8 +38,6 @@ RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
 
   context 'when the payment exceeds the outstanding balance of a loan' do
     it 'should return a error message' do
-      loan = Loan.create(funded_amount: 10_000.00)
-
       post "/api/v1/loans/#{loan.id}/payments", payment: { amount: 12_000.00 }
 
       expect(response.status).to eq 400

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
     end
   end
 
+  context 'with invalid data' do
+    it 'should return validation errors' do
+      loan = Loan.create(funded_amount: 10_000.00)
+
+      post "/api/v1/loans/#{loan.id}/payments", payment: { amount: 'jf' }
+
+      expect(response.status).to eq 400
+
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response['errors']).to eq(
+        [
+          'Amount is invalid',
+          'Amount is not a number',
+          "Amount can't be blank"
+        ]
+      )
+    end
+  end
+
   context 'when the payment exceeds the outstanding balance of a loan' do
     it 'should return a error message' do
       loan = Loan.create(funded_amount: 10_000.00)

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
       expect(parsed_response['payment_date']).to eq payment.payment_date
     end
   end
+
+  context 'when the payment exceeds the outstanding balance of a loan' do
+    it 'should return a error message' do
+      loan = Loan.create(funded_amount: 10_000.00)
+
+      post "/api/v1/loans/#{loan.id}/payments", payment: { amount: 12_000.00 }
+
+      expect(response.status).to eq 400
+
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response.errors[0]).to eq 'Payment exceeds the outstanding balance'
+    end
+  end
 end


### PR DESCRIPTION
- Allows users to create a payment for a specified loan
- Does not allow a user to create a payment that exceeds the current balance of a loan
- Displays the payment object on successful creation
- Displays error validation messages on a unsuccesful response
- Requests specs and model specs added for the implementation
- The endpoint for creating a payment is `POST /api/v1/loans/:loan_id/payments`
- The payload that it is expecting is: `{ "payment": { "amount": "1000" } }`

Fixes #1
