### PR TITLE
Expose outstanding balance for loans

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'responders', '~> 2.0'
+gem 'active_model_serializers', '~> 0.10.0'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.1)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
     activejob (4.2.4)
       activesupport (= 4.2.4)
       globalid (>= 0.3.0)
@@ -64,6 +69,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    jsonapi (0.1.1.beta2)
+      json (~> 1.8)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -168,6 +175,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::PaymentsController < ApiController
     loan = Loan.find(params[:loan_id])
     payment = loan.payments.new(payment_params)
 
-    if payment.save && loan.payment_under_balance?(payment)
+    if loan.payment_under_balance?(payment) && payment.save
       respond_with payment, location: nil
     else
       render json: { errors: payment.errors.full_messages }, status: :bad_request

--- a/app/controllers/loans_controller.rb
+++ b/app/controllers/loans_controller.rb
@@ -1,5 +1,4 @@
 class LoansController < ApplicationController
-
   rescue_from ActiveRecord::RecordNotFound do |exception|
     render json: 'not_found', status: :not_found
   end

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -6,7 +6,7 @@ class Loan < ActiveRecord::Base
   end
 
   def payment_under_balance?(payment)
-    if payment.amount.nil? || payment.amount > outstanding_balance
+    if payment.amount.to_f > outstanding_balance
       payment.errors.add(:amount, 'cannot exceed outstanding loan balance')
       return false
     end

--- a/app/serializers/loan_serializer.rb
+++ b/app/serializers/loan_serializer.rb
@@ -1,0 +1,3 @@
+class LoanSerializer < ActiveModel::Serializer
+  attributes :id, :funded_amount, :outstanding_balance, :created_at, :updated_at
+end

--- a/spec/requests/loans_spec.rb
+++ b/spec/requests/loans_spec.rb
@@ -24,3 +24,20 @@ RSpec.describe 'GET /loans', type: :request do
     expect(parsed_response[1]['outstanding_balance']).to eq second_loan_balance.to_s
   end
 end
+
+RSpec.describe 'GET /loans/:id', type: :request do
+  it 'exposes outstanding balance for a specific loan' do
+    first_loan_payment = first_loan.payments.create(amount: 2000.0)
+    first_loan_balance = first_loan.funded_amount - first_loan_payment.amount
+
+    get "/loans/#{first_loan.id}"
+
+    expect(response.status).to eq 200
+
+    parsed_response = JSON.parse(response.body)
+
+    expect(parsed_response['id']).to eq first_loan.id
+    expect(parsed_response['funded_amount']).to eq first_loan.funded_amount.to_s
+    expect(parsed_response['outstanding_balance']).to eq first_loan_balance.to_s
+  end
+end

--- a/spec/requests/loans_spec.rb
+++ b/spec/requests/loans_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /loans', type: :request do
+  let(:first_loan) { Loan.create(funded_amount: 5000.0) }
+  let(:second_loan) { Loan.create(funded_amount: 10_000.0) }
+
+  it 'exposes outstanding balance for loans' do
+    first_loan_payment = first_loan.payments.create(amount: 2000.0)
+    second_loan_payment = second_loan.payments.create(amount: 3000.0)
+    first_loan_balance = first_loan.funded_amount - first_loan_payment.amount
+    second_loan_balance = second_loan.funded_amount - second_loan_payment.amount
+
+    get '/loans'
+
+    expect(response.status).to eq 200
+
+    parsed_response = JSON.parse(response.body)
+
+    expect(parsed_response[0]['id']).to eq first_loan.id
+    expect(parsed_response[0]['funded_amount']).to eq first_loan.funded_amount
+    expect(parsed_response[0]['outstanding_balance']).to eq first_loan_balance
+    expect(parsed_response[1]['id']).to eq second_loan.id
+    expect(parsed_response[1]['funded_amount']).to eq second_loan.funded_amount
+    expect(parsed_response[1]['outstanding_balance']).to eq second_loan_balance
+  end
+end

--- a/spec/requests/loans_spec.rb
+++ b/spec/requests/loans_spec.rb
@@ -26,18 +26,20 @@ RSpec.describe 'GET /loans', type: :request do
 end
 
 RSpec.describe 'GET /loans/:id', type: :request do
-  it 'exposes outstanding balance for a specific loan' do
-    first_loan_payment = first_loan.payments.create(amount: 2000.0)
-    first_loan_balance = first_loan.funded_amount - first_loan_payment.amount
+  let(:loan) { Loan.create(funded_amount: 5000.0) }
 
-    get "/loans/#{first_loan.id}"
+  it 'exposes outstanding balance for a specific loan' do
+    loan_payment = loan.payments.create(amount: 2000.0)
+    loan_balance = loan.funded_amount - loan_payment.amount
+
+    get "/loans/#{loan.id}"
 
     expect(response.status).to eq 200
 
     parsed_response = JSON.parse(response.body)
 
-    expect(parsed_response['id']).to eq first_loan.id
-    expect(parsed_response['funded_amount']).to eq first_loan.funded_amount.to_s
-    expect(parsed_response['outstanding_balance']).to eq first_loan_balance.to_s
+    expect(parsed_response['id']).to eq loan.id
+    expect(parsed_response['funded_amount']).to eq loan.funded_amount.to_s
+    expect(parsed_response['outstanding_balance']).to eq loan_balance.to_s
   end
 end

--- a/spec/requests/loans_spec.rb
+++ b/spec/requests/loans_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe 'GET /loans', type: :request do
     parsed_response = JSON.parse(response.body)
 
     expect(parsed_response[0]['id']).to eq first_loan.id
-    expect(parsed_response[0]['funded_amount']).to eq first_loan.funded_amount
-    expect(parsed_response[0]['outstanding_balance']).to eq first_loan_balance
+    expect(parsed_response[0]['funded_amount']).to eq first_loan.funded_amount.to_s
+    expect(parsed_response[0]['outstanding_balance']).to eq first_loan_balance.to_s
     expect(parsed_response[1]['id']).to eq second_loan.id
-    expect(parsed_response[1]['funded_amount']).to eq second_loan.funded_amount
-    expect(parsed_response[1]['outstanding_balance']).to eq second_loan_balance
+    expect(parsed_response[1]['funded_amount']).to eq second_loan.funded_amount.to_s
+    expect(parsed_response[1]['outstanding_balance']).to eq second_loan_balance.to_s
   end
 end


### PR DESCRIPTION
- Adds the ability to see the outstanding balance for all loans and individual loans
- Includes request specs for both `/loans` and `/loans/:id`
- Used `active_model_serializers` to control what is displayed in the response

Fixes #2 
