### PR TITLE
Expose endpoint for seeing all payments for a loan

### DIFF
--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -1,4 +1,8 @@
 class Api::V1::PaymentsController < ApiController
+  def index
+    respond_with Loan.find(params[:loan_id]).payments
+  end
+
   def create
     loan = Loan.find(params[:loan_id])
     payment = loan.payments.new(payment_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
       resources :loans, only: [:show] do
-        resources :payments, only: [:create]
+        resources :payments, only: [:index, :create]
       end
     end
   end

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -48,3 +48,25 @@ RSpec.describe 'POST /api/v1/loans/:load_id/payments', type: :request do
     end
   end
 end
+
+RSpec.describe 'GET /api/v1/loans/:loan_id/payments' do
+  let(:loan) { Loan.create(funded_amount: 10_000.0) }
+
+  it 'shows all payments for the specified loan' do
+    first_payment = loan.payments.create(amount: 2000.0)
+    second_payment = loan.payments.create(amount: 4000.0)
+
+    get "/api/v1/loans/#{loan.id}/payments"
+
+    expect(response.status).to eq 200
+
+    parsed_response = JSON.parse(response.body)
+
+    expect(parsed_response[0]['id']).to eq first_payment.id
+    expect(parsed_response[0]['amount']).to eq first_payment.amount.to_s
+    expect(parsed_response[0]['payment_date']).to eq first_payment.payment_date
+    expect(parsed_response[1]['id']).to eq second_payment.id
+    expect(parsed_response[1]['amount']).to eq second_payment.amount.to_s
+    expect(parsed_response[1]['payment_date']).to eq second_payment.payment_date
+  end
+end


### PR DESCRIPTION
- Give the client all payments for a specified loan
- The route to access this is: `/api/v1/loans/:loan_id/payments`
- Associated request spec that tests that all payments are returned

Fixes #3 
