### PR TITLE
Expose endpoint for seeing an individual payment for a given loan

### DIFF
--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -3,6 +3,11 @@ class Api::V1::PaymentsController < ApiController
     respond_with Loan.find(params[:loan_id]).payments
   end
 
+  def show
+    payments = Loan.find(params[:loan_id]).payments
+    respond_with payments.find(params[:id])
+  end
+
   def create
     loan = Loan.find(params[:loan_id])
     payment = loan.payments.new(payment_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
       resources :loans, only: [:show] do
-        resources :payments, only: [:index, :create]
+        resources :payments, only: [:index, :show, :create]
       end
     end
   end

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -70,3 +70,22 @@ RSpec.describe 'GET /api/v1/loans/:loan_id/payments' do
     expect(parsed_response[1]['payment_date']).to eq second_payment.payment_date
   end
 end
+
+RSpec.describe 'GET /api/v1/loans/:loan_id/payments/:id' do
+  let(:loan) { Loan.create(funded_amount: 10_000.0) }
+
+  it 'shows all payments for the specified loan' do
+    loan.payments.create(amount: 2000.0)
+    second_payment = loan.payments.create(amount: 4000.0)
+
+    get "/api/v1/loans/#{loan.id}/payments/{second_payment.id}"
+
+    expect(response.status).to eq 200
+
+    parsed_response = JSON.parse(response.body)
+
+    expect(parsed_response['id']).to eq second_payment.id
+    expect(parsed_response['amount']).to eq second_payment.amount.to_s
+    expect(parsed_response['payment_date']).to eq second_payment.payment_date
+  end
+end

--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'GET /api/v1/loans/:loan_id/payments/:id' do
     loan.payments.create(amount: 2000.0)
     second_payment = loan.payments.create(amount: 4000.0)
 
-    get "/api/v1/loans/#{loan.id}/payments/{second_payment.id}"
+    get "/api/v1/loans/#{loan.id}/payments/#{second_payment.id}"
 
     expect(response.status).to eq 200
 


### PR DESCRIPTION
- Allows a client to view an individual payment for a given loan
- The endpoint is: `/api/v1/loans/:loan_id/payments/:id`
- Associated request spec to test that we only see the specified payment

Fixes #4 
